### PR TITLE
Jest version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Dakuan/gulp-jest",
   "dependencies": {
-    "jest-cli": "^0.1.18",
+    "jest-cli": "^0.2.1",
     "gulp-util": "^3.0.0",
     "through2": "^0.5.1",
     "react-tools": "^0.12.1"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gulp plugin for running your Jest tests",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test.js -t 10000"
+    "test": "mocha test.js -t 10000 --harmony"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
gulp-jest uses an old, 0.1 version ATM. It would be nice if the version would get bumped. :)

Shouldn't break things (at least didn't break any for me).