### PR TITLE
Bump Jest version for node v0.12 support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Dakuan/gulp-jest",
   "dependencies": {
-    "jest-cli": "^0.2.1",
+    "jest-cli": "^0.4.0",
     "gulp-util": "^3.0.0",
     "through2": "^0.5.1",
     "react-tools": "^0.12.1"


### PR DESCRIPTION
Bump Jest version for node v0.12 support.

https://github.com/facebook/jest/pull/261