### PR TITLE
Allowed Jest CLI arguments to be passed in as second argument.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ var jest = require('jest-cli'),
 
 module.exports = function (options, cliArgs) {
     options = options || {};
-    args = cliArgs || {};
-    arg.config = options;
+    var args = cliArgs || {};
+    args.config = options;
 
     return through.obj(function (file, enc, cb) {
         options.rootDir = options.rootDir || file.path;

--- a/index.js
+++ b/index.js
@@ -4,13 +4,14 @@ var jest = require('jest-cli'),
     gutil = require('gulp-util'),
     through = require('through2');
 
-module.exports = function (options) {
+module.exports = function (options, cliArgs) {
     options = options || {};
+    args = cliArgs || {};
+    arg.config = options;
+
     return through.obj(function (file, enc, cb) {
         options.rootDir = options.rootDir || file.path;
-        jest.runCLI({
-            config: options
-        }, options.rootDir, function (success) {
+        jest.runCLI(args, options.rootDir, function (success) {
             if(!success) {
                 cb(new gutil.PluginError('gulp-jest', { message: "Tests Failed" }));
             } else {


### PR DESCRIPTION
Hey @Dakuan,

We use gulp-jest in our production environment, and love it. I added this feature because we were hoping to use verbose mode with gulp-jest.

Hope you can use this!